### PR TITLE
Remove reference to CloudFormation

### DIFF
--- a/pcf-aws-manual-config.html.md.erb
+++ b/pcf-aws-manual-config.html.md.erb
@@ -683,7 +683,7 @@ The default persistent disk value is 50 GB. Pivotal recommends increasing this v
   1. From the **Load Balancers** page, select the load balancer.
   1. On the **Description** tab, locate the **Basic Configuration** section and record the **DNS name** of the load balancer.
 1. Click **Instances** on the left navigation to view your EC2 instances.
-1. Select the `PcfOpsManInstance` instance created by Cloudformation.
+1. Select the Ops Manager instance created during Step 12.
 1. On the **Description** tab, record the value for **IPv4 Public IP**.
 1. Navigate to your DNS provider and create the following CNAME and A records:
   * CNAME: `*.apps.YOUR-SYSTEM-DOMAIN.com` and `*.system.YOUR-SYSTEM-DOMAIN.com` points to the DNS name of the `pcf-web-elb` load balancer.


### PR DESCRIPTION
Since this page talks exclusively about manually creating AWS, we do not need reference to CloudFormation, so it is removed from the DNS section.